### PR TITLE
Remove division by two in TrySerialize->VarFileInfo to fix properties not displaying.

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -315,7 +315,7 @@ impl TrySerialize for VersionInfoChild {
                     let var_record = try_build_struct(
                         k,
                         DataType::Binary,
-                        data.len() / 2,
+                        data.len(),
                         &u32slice_to_u8vec(data),
                     )?;
                     var_records.try_align_u32()?;


### PR DESCRIPTION
This fixes the bug described here: [winres_edit_issue](https://github.com/Alcinzal/winres_edit_issue)

I don't know why.